### PR TITLE
Ensure we get DeviceAdded signals when daemon starts

### DIFF
--- a/boltd/bolt-daemon.c
+++ b/boltd/bolt-daemon.c
@@ -117,6 +117,7 @@ on_name_acquired (GDBusConnection *connection,
                   gpointer         user_data)
 {
   bolt_debug (LOG_TOPIC ("dbus"), "got the name");
+  bolt_manager_got_the_name (manager);
 }
 
 static void

--- a/boltd/bolt-manager.c
+++ b/boltd/bolt-manager.c
@@ -1447,3 +1447,36 @@ bolt_manager_export (BoltManager     *mgr,
 
   return TRUE;
 }
+
+void
+bolt_manager_got_the_name (BoltManager *mgr)
+{
+
+  /* emit DeviceAdded signals now that we have the name
+   * for all devices that are not stored and connected
+   */
+  for (guint i = 0; i < mgr->devices->len; i++)
+    {
+      BoltDevice *dev = g_ptr_array_index (mgr->devices, i);
+      BoltStatus status;
+      gboolean stored;
+      const char *opath;
+
+      stored = bolt_device_get_stored (dev);
+      if (stored)
+        continue;
+
+      status = bolt_device_get_status (dev);
+      if (status != BOLT_STATUS_CONNECTED)
+        continue;
+
+      opath = bolt_exported_get_object_path (BOLT_EXPORTED (dev));
+      if (opath == NULL)
+        continue;
+
+      bolt_exported_emit_signal (BOLT_EXPORTED (mgr),
+                                 "DeviceAdded",
+                                 g_variant_new ("(o)", opath),
+                                 NULL);
+    }
+}

--- a/boltd/bolt-manager.h
+++ b/boltd/bolt-manager.h
@@ -31,4 +31,6 @@ gboolean         bolt_manager_export (BoltManager     *mgr,
                                       GDBusConnection *connection,
                                       GError         **error);
 
+void             bolt_manager_got_the_name (BoltManager *mgr);
+
 G_END_DECLS

--- a/tests/test-integration
+++ b/tests/test-integration
@@ -113,8 +113,9 @@ class Signal(object):
         if self._bridge is not None:
             raise ValueError('already bridged')
         self._bridge = {'object': obj,
-                        'name': name,
-                        'filter': callback}
+                        'name': name}
+        if callback is not None:
+            self._bridge['filter'] = callback
 
     def birdge_destroy(self):
         self._bridge = None
@@ -202,11 +203,13 @@ class Recorder(object):
         self.events = []
         self.target = target
         self.target.g_properties_changed += self._on_props_changed
+        self.target.g_signal += self._on_signal
 
     def close(self):
         if not self.recording:
             return
         self.target.g_properties_changed -= self._on_props_changed
+        self.target.g_signal -= self._on_signal
         self.recording = False
         return self.events
 
@@ -221,6 +224,11 @@ class Recorder(object):
         for k, v in props.items():
             e = self.Event('property', k, v, now)
             self._add_event(e)
+
+    def _on_signal(self, proxy, sender, signal, params):
+        now = time.time()
+        e = self.Event('signal', signal, None, now)
+        self._add_event(e)
 
     def _add_event(self, event):
         self.events.append(event)
@@ -271,7 +279,7 @@ class Recorder(object):
 
 @Signal.enable
 class ProxyWrapper(object):
-    signals = ['g_properties_changed']
+    signals = ['g_properties_changed', 'g_signal']
 
     def __init__(self, bus, iname, path):
         self._proxy = Gio.DBusProxy.new_sync(bus,
@@ -288,6 +296,8 @@ class ProxyWrapper(object):
         self.g_properties_changed.bridge(self._proxy,
                                          'g-properties-changed',
                                          props_changed)
+
+        self.g_signal.bridge(self._proxy, 'g-signal', None)
 
     def __getattr__(self, name):
         if name.startswith('_'):
@@ -365,6 +375,7 @@ class BoltDevice(ProxyWrapper):
                                     -1,
                                     None)
         return res is not None
+
 
 @Signal.enable
 class BoltClient(ProxyWrapper):

--- a/tests/test-integration
+++ b/tests/test-integration
@@ -947,6 +947,22 @@ class BoltTest(dbusmock.DBusTestCase):
         self.assertEqual(len(devices), 0)
         self.daemon_stop()
 
+    def test_signals_on_start(self):
+        # Check that we get DeviceAdded signals for un-authorized
+        # devices that are not in the database
+
+        client = BoltClient(self.dbus)
+        tree = self.default_mock_tree()
+        tree.connect_tree(self.testbed)
+
+        with client.record() as tape:
+            self.daemon_start()
+            res = tape.wait_for_event('signal',
+                                      'DeviceAdded',
+                                      None)
+            self.assertTrue(res)
+        self.daemon_stop()
+
     def test_basic_device_name(self):
         domain = 0
         security = 'secure'


### PR DESCRIPTION
When the daemon gets started and unauthorized devices are already connected we expect the daemon to emit DeviceAdded signals. Ensure this by emitting DeviceAdded signals for all relevant devices after we got the bus name.