### PR TITLE
Allow building, even if integration tests cannot be run

### DIFF
--- a/contrib/bolt.spec.in
+++ b/contrib/bolt.spec.in
@@ -13,6 +13,9 @@ BuildRequires: pkgconfig(gio-2.0)
 BuildRequires: pkgconfig(libudev)
 BuildRequires: pkgconfig(systemd)
 BuildRequires: polkit-devel
+BuildRequires: pygobject3-devel
+BuildRequires: python3-dbus
+BuildRequires: python3-dbusmock
 BuildRequires: umockdev-devel
 BuildRequires: systemd
 %{?systemd_requires}

--- a/meson.build
+++ b/meson.build
@@ -366,6 +366,8 @@ if res.returncode() == 0
     name = 'integration @0@'.format(t.split('.')[1])
     test(name, test_it, args: [t], env: test_env, timeout: 120)
   endforeach
+else
+  warning('ntegration tests not run: (@0@'.format(res.stderr().strip()))
 endif
 
 # contrib

--- a/meson.build
+++ b/meson.build
@@ -378,7 +378,7 @@ spec_file = configure_file(
 
 # documentation
 
-build_man = build_man != false and a2x.found()
+build_man = build_man != 'false' and a2x.found()
 if build_man
 
   foreach page : [

--- a/tests/test-integration
+++ b/tests/test-integration
@@ -43,7 +43,7 @@ try:
     import dbusmock
 except ImportError as e:
     sys.stderr.write('Skipping integration test due to missing depdendencies: %s\n' % str(e))
-    sys.exit(0)
+    sys.exit(1)
 
 
 try:


### PR DESCRIPTION
Currently we fail in meson