### PR TITLE
Add a simple packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,23 @@
+# https://packit.dev/docs/configuration/
+
+specfile_path: bolt.spec
+
+synced_files:
+    - bolt.spec
+    - .packit.yaml
+
+upstream_package_name: bolt
+downstream_package_name: bolt
+
+copy_upstream_release_description: true
+
+actions:
+  get-current-version: bash -c "git describe --tags --abbrev=0 | sed 's|v||'"
+
+create_pr: true
+jobs:
+- job: propose_downstream
+  trigger: release
+  metadata:
+    dist_git_branches:
+      - fedora-all


### PR DESCRIPTION
Before this can be merged this repo needs to be updated and there needs to be an actual sync between this repo and the original repo (see these docs: https://docs.gitlab.com/ee/user/project/repository/mirror/).

For the moment, this config only proposes downstream PRs in all active Fedora releases (maybe this needs to be adjusted, not sure which releases you actually want to support).
In a later stage, the create_pr setting can be switched to false, then packit will just push to dist-git (could also do that straight away if you feel comfortable with it).

Finally, to make packit work you ofc need to configure the as-a-service thingy in the repository's settings.